### PR TITLE
accommodate changes in 'pomp' v 1.18.6.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: panelPomp
 Type: Package
 Title: Statistical Inference for PanelPOMPs (Panel Partially Observed Markov Processes)
-Version: 0.8.1
-Date: 2018-04-30
+Version: 0.8.2
+Date: 2018-08-07
 Author: Carles Breto, Edward L. Ionides, Aaron A. King
 Maintainer: Carles Breto <cbreto@umich.edu>
 Description: Tools for working with PanelPOMPs, i.e., with
@@ -18,7 +18,7 @@ License: MIT + file LICENSE
 LazyData: TRUE
 Depends:
     R(>= 3.1.2),
-    pomp(>= 1.7.5.2)
+    pomp(>= 1.18.6.3)
 Imports:
     methods
 RoxygenNote: 6.0.1

--- a/R/mif2.R
+++ b/R/mif2.R
@@ -156,13 +156,9 @@ mif2.internal <- function (object, Nmif, start, Np, rw.sd, transform = FALSE,
       rownames(updated.paramMatrix) <- c(
         rownames(pParamMatrix), rownames(pparamArray))
       
-      ## note that we have to trick pomp into accepting the parameters through 
-      ## the .paramMatrix back-door.  If 'object' has no parameters and 'start' 
-      ## is not specified, then pomp::mif2 will throw an error.
       output[[unit]] <- tryCatch(
         pomp::mif2(
           object = object[[unit]],
-          start = setNames(nm=rownames(updated.paramMatrix)), # cheap pomp trick
           Nmif = 1,
           Np = Np,
           rw.sd = rw.sd[[unit]],

--- a/tests/aaa.Rout.save
+++ b/tests/aaa.Rout.save
@@ -1,5 +1,5 @@
 
-R version 3.5.0 (2018-04-23) -- "Joy in Playing"
+R version 3.5.1 (2018-07-02) -- "Feather Spray"
 Copyright (C) 2018 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
 

--- a/tests/example.Rout.save
+++ b/tests/example.Rout.save
@@ -1,5 +1,5 @@
 
-R version 3.5.0 (2018-04-23) -- "Joy in Playing"
+R version 3.5.1 (2018-07-02) -- "Feather Spray"
 Copyright (C) 2018 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
 

--- a/tests/examples.Rout.save
+++ b/tests/examples.Rout.save
@@ -1,5 +1,5 @@
 
-R version 3.5.0 (2018-04-23) -- "Joy in Playing"
+R version 3.5.1 (2018-07-02) -- "Feather Spray"
 Copyright (C) 2018 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
 

--- a/tests/get_col_row.Rout.save
+++ b/tests/get_col_row.Rout.save
@@ -1,5 +1,5 @@
 
-R version 3.5.0 (2018-04-23) -- "Joy in Playing"
+R version 3.5.1 (2018-07-02) -- "Feather Spray"
 Copyright (C) 2018 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
 

--- a/tests/mif2.Rout.save
+++ b/tests/mif2.Rout.save
@@ -1,5 +1,5 @@
 
-R version 3.5.0 (2018-04-23) -- "Joy in Playing"
+R version 3.5.1 (2018-07-02) -- "Feather Spray"
 Copyright (C) 2018 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
 
@@ -108,7 +108,7 @@ Error : in ‘mif2’: pomp's ‘mif2’ error message: in ‘mif2’: the follo
 > ##  wrong shared names
 > try(mif2(ppo,Np=10,sh=c(sth=0),rw.sd=rw.sd(X.0=0.2),cooling.fraction.50=0.5,
 +           cooling.type="geometric"))
-Error : in ‘mif2’: pomp's ‘mif2’ error message: in ‘mif2’: in ‘mif2.pfilter’: process simulation error: in ‘discrete.time.sim’ plugin: variable 'sigmaY' not found among the parameters (panelPomp:::mif2.internal)
+Error : in ‘mif2’: pomp's ‘mif2’ error message: in ‘mif2’: in ‘mif2.pfilter’: process simulation error: variable 'sigmaY' not found among the parameters (panelPomp:::mif2.internal)
 > 
 > mf <- mif2(ppo,Np=10,rw.sd=rw.sd(X.0=0.2),
 +            cooling.fraction.50=0.5,cooling.type="geometric")

--- a/tests/mif2_intern.Rout.save
+++ b/tests/mif2_intern.Rout.save
@@ -1,5 +1,5 @@
 
-R version 3.5.0 (2018-04-23) -- "Joy in Playing"
+R version 3.5.1 (2018-07-02) -- "Feather Spray"
 Copyright (C) 2018 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
 

--- a/tests/panelPomp.Rout.save
+++ b/tests/panelPomp.Rout.save
@@ -1,5 +1,5 @@
 
-R version 3.5.0 (2018-04-23) -- "Joy in Playing"
+R version 3.5.1 (2018-07-02) -- "Feather Spray"
 Copyright (C) 2018 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
 

--- a/tests/panelPomp_methods.Rout.save
+++ b/tests/panelPomp_methods.Rout.save
@@ -1,5 +1,5 @@
 
-R version 3.5.0 (2018-04-23) -- "Joy in Playing"
+R version 3.5.1 (2018-07-02) -- "Feather Spray"
 Copyright (C) 2018 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
 

--- a/tests/panel_loglik.Rout.save
+++ b/tests/panel_loglik.Rout.save
@@ -1,5 +1,5 @@
 
-R version 3.5.0 (2018-04-23) -- "Joy in Playing"
+R version 3.5.1 (2018-07-02) -- "Feather Spray"
 Copyright (C) 2018 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
 

--- a/tests/params.Rout.save
+++ b/tests/params.Rout.save
@@ -1,5 +1,5 @@
 
-R version 3.5.0 (2018-04-23) -- "Joy in Playing"
+R version 3.5.1 (2018-07-02) -- "Feather Spray"
 Copyright (C) 2018 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
 

--- a/tests/pfilter.Rout.save
+++ b/tests/pfilter.Rout.save
@@ -1,5 +1,5 @@
 
-R version 3.5.0 (2018-04-23) -- "Joy in Playing"
+R version 3.5.1 (2018-07-02) -- "Feather Spray"
 Copyright (C) 2018 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
 

--- a/tests/print-results.Rout.save
+++ b/tests/print-results.Rout.save
@@ -1,5 +1,5 @@
 
-R version 3.5.0 (2018-04-23) -- "Joy in Playing"
+R version 3.5.1 (2018-07-02) -- "Feather Spray"
 Copyright (C) 2018 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
 
@@ -37,23 +37,8 @@ summary of data:
  3rd Qu.:2.526  
  Max.   :3.402  
 zero time, t0 = 0
-process model simulator, rprocess = function (xstart, times, params, ..., zeronames = character(0), 
-    tcovar, covar, .getnativesymbolinfo = TRUE) 
-{
-    tryCatch(.Call(euler_model_simulator, func = efun, xstart = xstart, 
-        times = times, params = params, deltat = object@delta.t, 
-        method = 2L, zeronames = zeronames, tcovar = tcovar, 
-        covar = covar, args = pairlist(...), gnsi = .getnativesymbolinfo), 
-        error = function(e) {
-            stop(ep, conditionMessage(e), call. = FALSE)
-        })
-}
-<bytecode: 0x304c910>
-<environment: 0x319d660>
-process model density, dprocess = function (x, times, params, log = FALSE, ...) 
-stop(sQuote("dprocess"), " not specified", call. = FALSE)
-<bytecode: 0x42c65f8>
-<environment: 0x2290b40>
+discrete-time process-model simulator, step.fun = native function ‘__pomp_stepfn’, defined by a Csnippet
+process model density, dprocess = not specified
 measurement model simulator, rmeasure = native function ‘__pomp_rmeasure’, defined by a Csnippet
 measurement model density, dmeasure = native function ‘__pomp_dmeasure’, defined by a Csnippet
 prior simulator, rprior = not specified
@@ -75,23 +60,8 @@ summary of data:
  3rd Qu.:2.6189  
  Max.   :4.7310  
 zero time, t0 = 0
-process model simulator, rprocess = function (xstart, times, params, ..., zeronames = character(0), 
-    tcovar, covar, .getnativesymbolinfo = TRUE) 
-{
-    tryCatch(.Call(euler_model_simulator, func = efun, xstart = xstart, 
-        times = times, params = params, deltat = object@delta.t, 
-        method = 2L, zeronames = zeronames, tcovar = tcovar, 
-        covar = covar, args = pairlist(...), gnsi = .getnativesymbolinfo), 
-        error = function(e) {
-            stop(ep, conditionMessage(e), call. = FALSE)
-        })
-}
-<bytecode: 0x304c910>
-<environment: 0x4412280>
-process model density, dprocess = function (x, times, params, log = FALSE, ...) 
-stop(sQuote("dprocess"), " not specified", call. = FALSE)
-<bytecode: 0x42c65f8>
-<environment: 0x402a008>
+discrete-time process-model simulator, step.fun = native function ‘__pomp_stepfn’, defined by a Csnippet
+process model density, dprocess = not specified
 measurement model simulator, rmeasure = native function ‘__pomp_rmeasure’, defined by a Csnippet
 measurement model density, dmeasure = native function ‘__pomp_dmeasure’, defined by a Csnippet
 prior simulator, rprior = not specified

--- a/tests/seeded-results.Rout.save
+++ b/tests/seeded-results.Rout.save
@@ -1,5 +1,5 @@
 
-R version 3.5.0 (2018-04-23) -- "Joy in Playing"
+R version 3.5.1 (2018-07-02) -- "Feather Spray"
 Copyright (C) 2018 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
 


### PR DESCRIPTION
This pull request changes 'mif2.R' slightly because there is now no need to trick pomp into allowing the parameters to be fed in using '.paramMatrix'.  The tests are also updated to correspond with the latest 'pomp' release.