### PR TITLE
add test-coverage, badges

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,0 +1,32 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+    branches: [master]
+    
+name: test-coverage
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: covr
+
+      - name: Test coverage
+        run: covr::codecov()
+        shell: Rscript {0}

--- a/README.md
+++ b/README.md
@@ -2,5 +2,8 @@
 
 ### an *R* package for statistical inference on panel partially observed Markov processes (alpha release version).
 
-[![Build Status](https://travis-ci.org/kingaa/panelPomp.svg?branch=zero_tolerance)](https://travis-ci.org/kingaa/panelPomp)
-[![codecov](https://codecov.io/gh/kingaa/panelPomp/branch/zero_tolerance/graph/badge.svg)](https://codecov.io/gh/kingaa/panelPomp/branch/zero_tolerance)
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[![R-CMD-check](https://github.com/cbreto/panelPomp/actions/workflows/r-cmd-check.yml/badge.svg)](https://github.com/cbreto/panelPomp/actions/workflows/r-cmd-check.yml)
+[![binary-build](https://github.com/cbreto/panelPomp/actions/workflows/binary-build.yml/badge.svg)](https://github.com/cbreto/panelPomp/actions/workflows/binary-build.yml)
+[![test-coverage](https://github.com/cbreto/panelPomp/actions/workflows/test-coverage.yml/badge.svg)](https://github.com/cbreto/panelPomp/actions/workflows/test-coverage.yml)
+[![codecov](https://codecov.io/gh/kingaa/panelPomp/branch/master/graph/badge.svg?token=8NkFKJJSRZ)](https://codecov.io/gh/kingaa/panelPomp)


### PR DESCRIPTION
This one adds another Github action and some badges to the README to display the results of all these tests.