### PR TITLE
do not use internal functions from other packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: panelPomp
 Type: Package
 Title: Inference for Panel Partially Observed Markov Processes
-Version: 1.1.0.0
-Date: 2023-03-27
+Version: 1.1.0.1
+Date: 2023-03-29
 Authors@R: c(person(given="Carles",family="Breto",role=c("aut","cre"),email="carles.breto@uv.es",comment=c(ORCID="0000-0003-4695-4902")),
 	person(given=c("Edward","L."),family="Ionides",role="aut",comment=c(ORCID="0000-0002-4190-0174")),
 	person(given=c("Aaron","A."),family="King",role="aut",comment=c(ORCID="0000-0001-6159-3207")))

--- a/R/package.R
+++ b/R/package.R
@@ -84,3 +84,12 @@
 NULL        # replacing NULL by "_PACKAGE" results in roxygen2 adding an
             # \alias{} with the package name, conflicting with functions named
             # after the package
+
+pStop <- function (fn, ...) {
+  fn <- as.character(fn) # nocov
+  stop("in ",sQuote(fn[1L]),": ",...,call.=FALSE) #nocov
+}
+
+pStop_ <- function (...) {
+  stop(...,call.=FALSE) #nocov
+}

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -28,14 +28,14 @@ setMethod(
   definition=function (object,nsim = 1,shared,specific) {
 
   if (length(nsim)!=1 || !is.numeric(nsim) || !is.finite(nsim) || nsim < 1)
-    pomp:::pStop_(sQuote("nsim")," must be a positive integer.")
+    pStop_(sQuote("nsim")," must be a positive integer.")
   nsim <- as.integer(nsim)
 
   if (!missing(shared))  object@shared <- shared
   if (!missing(specific)) object@specific <- specific
 
   if (length(object@shared)==0 & length(object@specific)==0)
-    pomp:::pStop_("at least one of shared and specific must be specified.")
+    pStop_("at least one of shared and specific must be specified.")
 
   ppList <- lapply(1:nsim,function(n,pp1){
     pompList <- lapply(1:length(pp1),function(u,pp1)


### PR DESCRIPTION
Just in time for version 1.1.0.1!  Seriously, though, sorry I forgot to make a pull request earlier.

This one just avoids the need to use non-exported functions from **pomp**.