### PR TITLE
Minor bug fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,12 @@
 Package: panelPomp
 Type: Package
 Title: Inference for Panel Partially Observed Markov Processes
-Version: 1.1.0.1
-Date: 2023-03-29
+Version: 1.1.0.2
+Date: 2023-05-22
 Authors@R: c(person(given="Carles",family="Breto",role=c("aut","cre"),email="carles.breto@uv.es",comment=c(ORCID="0000-0003-4695-4902")),
 	person(given=c("Edward","L."),family="Ionides",role="aut",comment=c(ORCID="0000-0002-4190-0174")),
-	person(given=c("Aaron","A."),family="King",role="aut",comment=c(ORCID="0000-0001-6159-3207")))
+	person(given=c("Aaron","A."),family="King",role="aut",comment=c(ORCID="0000-0001-6159-3207")),
+	person(given="Jesse",family="Wheeler",role="aut",comment=c(ORCID="0000-0003-3941-3884")))
 Description: Data analysis based on panel partially-observed Markov process (PanelPOMP) models. To implement such models, simulate them and fit them to panel data, 'panelPomp' extends some of the facilities provided for time series data by the 'pomp' package. Implemented methods include filtering (panel particle filtering) and maximum likelihood estimation (Panel Iterated Filtering) as proposed in Breto, Ionides and King (2020) "Panel Data Analysis via Mechanistic Models" <doi:10.1080/01621459.2019.1604367>.
 License: GPL-3
 Depends:

--- a/R/mif2.R
+++ b/R/mif2.R
@@ -280,6 +280,9 @@ setMethod(
     if (missing(shared.start)) shared.start <- start$shared
     if (missing(specific.start)) specific.start <- start$specific
 
+    if (length(intersect(names(shared.start), rownames(specific.start))) > 0)
+      stop(wQuotes(ep, "a parameter cannot be both shared and specific!", et), call. = FALSE)
+
     if (missing(Np)) {
       stop(wQuotes(ep,"Missing ''Np'' argument.",et),call.=FALSE)
     }
@@ -297,7 +300,7 @@ setMethod(
       start=list(shared=shared.start,specific=specific.start),
       Np=Np,
       rw.sd=rw.sd,
-      cooling.type=cooling.type,
+      cooling.type=match.arg(cooling.type),
       cooling.fraction.50=cooling.fraction.50,
       verbose=verbose,
       block=block,
@@ -333,6 +336,10 @@ setMethod(
     }
     if (missing(shared.start)) shared.start <- start$shared
     if (missing(specific.start)) specific.start <- start$specific
+
+    if (length(intersect(names(shared.start), rownames(specific.start))) > 0)
+      stop(wQuotes(ep, "a parameter cannot be both shared and specific!", et), call. = FALSE)
+
     if (missing(Np)) Np <- object@Np
     if (missing(rw.sd)) rw.sd <- object@prw.sd
     if (missing(cooling.type)) cooling.type <- object@cooling.type

--- a/R/panelPomp_methods.R
+++ b/R/panelPomp_methods.R
@@ -132,10 +132,13 @@ setMethod(
 #' pParams(coef(prw))
 #' @export
 pParams <- function (value) {
-  nn <- grep("^.+\\[.+?\\]$",names(value),perl=TRUE,value=TRUE)
-  shs <- names(value)[!names(value)%in%nn]
-  pp <- sub(pattern="^(.+?)\\[.+?\\]$",replacement="\\1",x=nn,perl=TRUE)
-  sps <- sort(unique(pp))
+
+  if (!is.vector(value)) stop("input must be a vector.")
+
+  nn <- grep("^.+\\[.+?\\]$", names(value), perl = TRUE, value = TRUE)
+  shs <- names(value)[!names(value) %in% nn]
+  sps <- unique(sub(pattern="^(.+?)\\[.+?\\]$",replacement="\\1",x=nn,perl=TRUE))
+  # sps <- sort(unique(pp))
   uu <- sub(pattern="^(.+?)\\[(.+?)\\]$",replacement="\\2",x=nn,perl=TRUE)
   us <- sort(unique(uu))
   pParams <- list(shared=numeric(0),specific=array(numeric(0),dim=c(0,0)))

--- a/R/panel_logmeanexp.R
+++ b/R/panel_logmeanexp.R
@@ -2,8 +2,12 @@
 NULL
 
 #' @title Log-mean-exp for panels
-#' @description \code{se = TRUE}, the jackknife se's from \code{logmeanexp} are
-#'  squared, summed and the squared root is taken.
+#' @description This function computes the \code{\link[pomp]{logmeanexp}} for each column
+#'    or row of a numeric matrix and sums the result. Because the loglikelihood
+#'    of a \code{panelPomp} object is the sum of the loglikelihoods of its units,
+#'    this function can be used to summarize replicated estimates of the
+#'    \code{panelPomp} model likelihood. If \code{se = TRUE}, the jackknife SE estimates
+#'    from \code{\link[pomp]{logmeanexp}} are squared, summed and the squared root is taken.
 #' @param x Matrix with the same number of replicated estimates for each panel
 #' unit loglikelihood.
 #' @param MARGIN The dimension of the matrix that corresponds to a panel unit

--- a/R/pfilter.R
+++ b/R/pfilter.R
@@ -100,12 +100,28 @@ setMethod(
 
     # Get starting parameter values from 'object,' 'start,' or 'params'
     if (missing(shared)){
-      if (!missing(params)) shared <- params$shared
-      else shared <- object@shared
+      if (!missing(params)) {
+        if (!is.null(params$shared)) {
+          shared <- params$shared
+        } else {
+          stop(
+            ep, wQuotes("''params'' must be a list containing ''shared'' and ''specific'' elements, or a named numeric vector"),
+            ".", call. = FALSE
+          )
+        }
+      } else shared <- object@shared
     }
     if (missing(specific)){
-      if (!missing(params)) specific <- params$specific
-      else specific <- object@specific
+      if (!missing(params)) {
+        if (!is.null(params$specific)) {
+          specific <- params$specific
+        } else {
+          stop(
+            ep, wQuotes("''params'' must be a list containing ''shared'' and ''specific'' elements, or a named numeric vector"),
+            ".", call. = FALSE
+          )
+        }
+      } else specific <- object@specific
     }
     if (!is.null(object@shared)){
       if (

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,5 +1,31 @@
 _N_e_w_s _f_o_r _p_a_c_k_a_g_e '_p_a_n_e_l_P_o_m_p'
 
+_C_h_a_n_g_e_s _i_n '_p_a_n_e_l_P_o_m_p' _v_e_r_s_i_o_n _1._1._0._2:
+
+        • Added a type check for the ‘params’ arguement of the
+          ‘pfilter’ function in order to throw more user friendly
+          error.
+
+        • A more user friendly error is thrown when the user specifies
+          a parameter as both shared and unit specific in the ‘mif2’
+          function.
+
+        • Added a ‘match.arg’ call in ‘mif2.internal’; this will allow
+          the default option for the ‘cooling.type’ argument in ‘mif2’
+          to no longer throw an error, and mimics the behaviour of the
+          ‘mif2’ function in the ‘pomp’ package.
+
+        • The ‘pParams’ function no longer changes the order of the
+          unit specific parameter names; this was causing an error
+          because the ‘barycentric’ parameter transformation requires
+          that the parameters are adjacent to one another in the
+          parameter vector.
+
+        • Improved documentation for ‘panel_logmeanexp’.
+
+        • More robust input checking for the ‘pfilter’ function with
+          user friendly error messages.
+
 _C_h_a_n_g_e_s _i_n '_p_a_n_e_l_P_o_m_p' _v_e_r_s_i_o_n _1._1._0:
 
         • Improved documentation and tests.

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,5 +1,24 @@
 \name{NEWS}
 \title{News for package `panelPomp'}
+\section{Changes in \pkg{panelPomp} version 1.1.0.2}{
+  \itemize{
+    \item Added a type check for the \code{params} arguement of the
+      \code{pfilter} function in order to throw more user friendly error.
+    \item A more user friendly error is thrown when the user specifies a
+      parameter as both shared and unit specific in the \code{mif2} function.
+    \item Added a \code{match.arg} call in \code{mif2.internal}; this will
+      allow the default option for the \code{cooling.type} argument in
+      \code{mif2} to no longer throw an error, and mimics the behaviour of the
+      \code{mif2} function in the \code{pomp} package.
+    \item The \code{pParams} function no longer changes the order of the unit
+      specific parameter names; this was causing an error because the
+      \code{barycentric} parameter transformation requires that the parameters
+      are adjacent to one another in the parameter vector.
+    \item Improved documentation for \code{panel_logmeanexp}.
+    \item More robust input checking for the \code{pfilter} function with
+      user friendly error messages.
+  }
+}
 \section{Changes in \pkg{panelPomp} version 1.1.0}{
   \itemize{
   \item Improved documentation and tests.

--- a/man/panel_logmeanexp.Rd
+++ b/man/panel_logmeanexp.Rd
@@ -20,8 +20,12 @@ A \code{numeric} value with the average panel log likelihood or, when
 \code{se = TRUE}, a \code{numeric} vector adding the corresponding standard error.
 }
 \description{
-\code{se = TRUE}, the jackknife se's from \code{logmeanexp} are
- squared, summed and the squared root is taken.
+This function computes the \code{\link[pomp]{logmeanexp}} for each column
+   or row of a numeric matrix and sums the result. Because the loglikelihood
+   of a \code{panelPomp} object is the sum of the loglikelihoods of its units,
+   this function can be used to summarize replicated estimates of the
+   \code{panelPomp} model likelihood. If \code{se = TRUE}, the jackknife SE estimates
+   from \code{\link[pomp]{logmeanexp}} are squared, summed and the squared root is taken.
 }
 \examples{
 ulls <- matrix(c(1,1,10,10),nr=2)

--- a/tests/mif2.R
+++ b/tests/mif2.R
@@ -24,8 +24,7 @@ test(wQuotes(ep,"pomp's ''mif2'' error message: in ''mif2'': the following ",
              "in ''params'': ''X.0''. (panelPomp:::mif2.internal)\n"),
      mif2(panelPomp(unitobjects(ppo)),Np=10,rw.sd=rw_sd(sigmaX=0.05,X.0=0.5),
          cooling.fraction.50=0.5,sh=pparams(ppo)$sh))
-test(wQuotes(ep,"pomp's ''mif2'' error message: in ''mif2'': 'arg' must be ",
-             "of length 1 (panelPomp:::mif2.internal)\n"),
+test(wQuotes(ep,"a parameter cannot be both shared and specific!", et),
      mif2(panelPomp(unitobjects(ppo),shared=coef(po)),Np=10,sp=pparams(ppo)$sp,
           rw.sd=rw_sd(sigmaX=0.05,X.0=0.5),cooling.fraction.50=0.5))
 ## assign parameters


### PR DESCRIPTION
Minor bug fixes and improvements to documentation. The primary goal of these changes is to improve user experience, primarily achieved by adding helpful error messages for previously unexpected inputs.

The following changes were made: 

- Added a type check for the `params` argument of the `pfilter` function in order to throw more user friendly error.
- A more user friendly error is thrown when the user specifies a parameter as both shared and unit specific in the `mif2` function.
- Added a `match.arg` call in `mif2.internal` this will allow the default option for the `cooling.type` argument in `mif2` to no longer throw an error, and mimics the behavior of the `mif2` function in the `pomp` package.
- The `pParams` function no longer changes the order of the unit specific parameter names; this was causing an error because the `barycentric` parameter transformation requires that the parameters are adjacent to one another in the parameter vector.
- Improved documentation for `panel_logmeanexp`.
- More robust input checking for the `pfilter` function with user friendly error messages.
