### PR TITLE
Minor bug edits + GitHub Actions 

### DIFF
--- a/.github/workflows/binary-build.yml
+++ b/.github/workflows/binary-build.yml
@@ -31,13 +31,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
 
-      - uses: r-lib/actions/setup-r@v2.3.1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2.3.1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck pomp
           

--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -22,11 +22,11 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-22.04,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,  r: 'release'}
           - {os: ubuntu-20.04,   r: '4.1.0'}
           - {os: macOS-11,       r: 'release'}
-          - {os: macOS-12,       r: 'release'}
+          - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
 
     env:
@@ -58,13 +58,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
 
-      - uses: r-lib/actions/setup-r@v2.3.1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2.3.1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
             any::rcmdcheck

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -21,11 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
 
-      - uses: r-lib/actions/setup-r@v2.3.1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2.3.1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
             any::covr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,12 @@
 Package: panelPomp
 Type: Package
 Title: Inference for Panel Partially Observed Markov Processes
-Version: 1.1.0.1
-Date: 2023-03-29
+Version: 1.1.0.2
+Date: 2023-05-22
 Authors@R: c(person(given="Carles",family="Breto",role=c("aut","cre"),email="carles.breto@uv.es",comment=c(ORCID="0000-0003-4695-4902")),
 	person(given=c("Edward","L."),family="Ionides",role="aut",comment=c(ORCID="0000-0002-4190-0174")),
-	person(given=c("Aaron","A."),family="King",role="aut",comment=c(ORCID="0000-0001-6159-3207")))
+	person(given=c("Aaron","A."),family="King",role="aut",comment=c(ORCID="0000-0001-6159-3207")),
+	person(given="Jesse",family="Wheeler",role="aut",comment=c(ORCID="0000-0003-3941-3884")))
 Description: Data analysis based on panel partially-observed Markov process (PanelPOMP) models. To implement such models, simulate them and fit them to panel data, 'panelPomp' extends some of the facilities provided for time series data by the 'pomp' package. Implemented methods include filtering (panel particle filtering) and maximum likelihood estimation (Panel Iterated Filtering) as proposed in Breto, Ionides and King (2020) "Panel Data Analysis via Mechanistic Models" <doi:10.1080/01621459.2019.1604367>.
 License: GPL-3
 Depends:

--- a/R/mif2.R
+++ b/R/mif2.R
@@ -280,6 +280,9 @@ setMethod(
     if (missing(shared.start)) shared.start <- start$shared
     if (missing(specific.start)) specific.start <- start$specific
 
+    if (length(intersect(names(shared.start), rownames(specific.start))) > 0)
+      stop(wQuotes(ep, "a parameter cannot be both shared and specific!", et), call. = FALSE)
+
     if (missing(Np)) {
       stop(wQuotes(ep,"Missing ''Np'' argument.",et),call.=FALSE)
     }
@@ -297,7 +300,7 @@ setMethod(
       start=list(shared=shared.start,specific=specific.start),
       Np=Np,
       rw.sd=rw.sd,
-      cooling.type=cooling.type,
+      cooling.type=match.arg(cooling.type),
       cooling.fraction.50=cooling.fraction.50,
       verbose=verbose,
       block=block,
@@ -333,6 +336,10 @@ setMethod(
     }
     if (missing(shared.start)) shared.start <- start$shared
     if (missing(specific.start)) specific.start <- start$specific
+
+    if (length(intersect(names(shared.start), rownames(specific.start))) > 0)
+      stop(wQuotes(ep, "a parameter cannot be both shared and specific!", et), call. = FALSE)
+
     if (missing(Np)) Np <- object@Np
     if (missing(rw.sd)) rw.sd <- object@prw.sd
     if (missing(cooling.type)) cooling.type <- object@cooling.type

--- a/R/panelPomp_methods.R
+++ b/R/panelPomp_methods.R
@@ -133,7 +133,8 @@ setMethod(
 #' @export
 pParams <- function (value) {
 
-  if (!is.vector(value)) stop("input must be a vector.")
+  ep <- wQuotes("in ''pParams'': ")
+  if (!is.vector(value)) stop(ep, "input must be a vector.", call. = FALSE)
 
   nn <- grep("^.+\\[.+?\\]$", names(value), perl = TRUE, value = TRUE)
   shs <- names(value)[!names(value) %in% nn]

--- a/R/panelPomp_methods.R
+++ b/R/panelPomp_methods.R
@@ -132,10 +132,13 @@ setMethod(
 #' pParams(coef(prw))
 #' @export
 pParams <- function (value) {
-  nn <- grep("^.+\\[.+?\\]$",names(value),perl=TRUE,value=TRUE)
-  shs <- names(value)[!names(value)%in%nn]
-  pp <- sub(pattern="^(.+?)\\[.+?\\]$",replacement="\\1",x=nn,perl=TRUE)
-  sps <- sort(unique(pp))
+
+  if (!is.vector(value)) stop("input must be a vector.")
+
+  nn <- grep("^.+\\[.+?\\]$", names(value), perl = TRUE, value = TRUE)
+  shs <- names(value)[!names(value) %in% nn]
+  sps <- unique(sub(pattern="^(.+?)\\[.+?\\]$",replacement="\\1",x=nn,perl=TRUE))
+  # sps <- sort(unique(pp))
   uu <- sub(pattern="^(.+?)\\[(.+?)\\]$",replacement="\\2",x=nn,perl=TRUE)
   us <- sort(unique(uu))
   pParams <- list(shared=numeric(0),specific=array(numeric(0),dim=c(0,0)))

--- a/R/panel_logmeanexp.R
+++ b/R/panel_logmeanexp.R
@@ -2,8 +2,12 @@
 NULL
 
 #' @title Log-mean-exp for panels
-#' @description \code{se = TRUE}, the jackknife se's from \code{logmeanexp} are
-#'  squared, summed and the squared root is taken.
+#' @description This function computes the \code{\link[pomp]{logmeanexp}} for each column
+#'    or row of a numeric matrix and sums the result. Because the loglikelihood
+#'    of a \code{panelPomp} object is the sum of the loglikelihoods of its units,
+#'    this function can be used to summarize replicated estimates of the
+#'    \code{panelPomp} model likelihood. If \code{se = TRUE}, the jackknife SE estimates
+#'    from \code{\link[pomp]{logmeanexp}} are squared, summed and the squared root is taken.
 #' @param x Matrix with the same number of replicated estimates for each panel
 #' unit loglikelihood.
 #' @param MARGIN The dimension of the matrix that corresponds to a panel unit

--- a/R/pfilter.R
+++ b/R/pfilter.R
@@ -100,12 +100,28 @@ setMethod(
 
     # Get starting parameter values from 'object,' 'start,' or 'params'
     if (missing(shared)){
-      if (!missing(params)) shared <- params$shared
-      else shared <- object@shared
+      if (!missing(params)) {
+        if (!is.null(params$shared)) {
+          shared <- params$shared
+        } else {
+          stop(
+            ep, wQuotes("''params'' must be a list containing ''shared'' and ''specific'' elements, or a named numeric vector"),
+            ".", call. = FALSE
+          )
+        }
+      } else shared <- object@shared
     }
     if (missing(specific)){
-      if (!missing(params)) specific <- params$specific
-      else specific <- object@specific
+      if (!missing(params)) {
+        if (!is.null(params$specific)) {
+          specific <- params$specific
+        } else {
+          stop(
+            ep, wQuotes("''params'' must be a list containing ''shared'' and ''specific'' elements, or a named numeric vector"),
+            ".", call. = FALSE
+          )
+        }
+      } else specific <- object@specific
     }
     if (!is.null(object@shared)){
       if (

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,5 +1,31 @@
 _N_e_w_s _f_o_r _p_a_c_k_a_g_e '_p_a_n_e_l_P_o_m_p'
 
+_C_h_a_n_g_e_s _i_n '_p_a_n_e_l_P_o_m_p' _v_e_r_s_i_o_n _1._1._0._2:
+
+        • Added a type check for the ‘params’ arguement of the
+          ‘pfilter’ function in order to throw more user friendly
+          error.
+
+        • A more user friendly error is thrown when the user specifies
+          a parameter as both shared and unit specific in the ‘mif2’
+          function.
+
+        • Added a ‘match.arg’ call in ‘mif2.internal’; this will allow
+          the default option for the ‘cooling.type’ argument in ‘mif2’
+          to no longer throw an error, and mimics the behaviour of the
+          ‘mif2’ function in the ‘pomp’ package.
+
+        • The ‘pParams’ function no longer changes the order of the
+          unit specific parameter names; this was causing an error
+          because the ‘barycentric’ parameter transformation requires
+          that the parameters are adjacent to one another in the
+          parameter vector.
+
+        • Improved documentation for ‘panel_logmeanexp’.
+
+        • More robust input checking for the ‘pfilter’ function with
+          user friendly error messages.
+
 _C_h_a_n_g_e_s _i_n '_p_a_n_e_l_P_o_m_p' _v_e_r_s_i_o_n _1._1._0:
 
         • Improved documentation and tests.

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,5 +1,24 @@
 \name{NEWS}
 \title{News for package `panelPomp'}
+\section{Changes in \pkg{panelPomp} version 1.1.0.2}{
+  \itemize{
+    \item Added a type check for the \code{params} arguement of the
+      \code{pfilter} function in order to throw more user friendly error.
+    \item A more user friendly error is thrown when the user specifies a
+      parameter as both shared and unit specific in the \code{mif2} function.
+    \item Added a \code{match.arg} call in \code{mif2.internal}; this will
+      allow the default option for the \code{cooling.type} argument in
+      \code{mif2} to no longer throw an error, and mimics the behaviour of the
+      \code{mif2} function in the \code{pomp} package.
+    \item The \code{pParams} function no longer changes the order of the unit
+      specific parameter names; this was causing an error because the
+      \code{barycentric} parameter transformation requires that the parameters
+      are adjacent to one another in the parameter vector.
+    \item Improved documentation for \code{panel_logmeanexp}.
+    \item More robust input checking for the \code{pfilter} function with
+      user friendly error messages.
+  }
+}
 \section{Changes in \pkg{panelPomp} version 1.1.0}{
   \itemize{
   \item Improved documentation and tests.

--- a/man/panel_logmeanexp.Rd
+++ b/man/panel_logmeanexp.Rd
@@ -20,8 +20,12 @@ A \code{numeric} value with the average panel log likelihood or, when
 \code{se = TRUE}, a \code{numeric} vector adding the corresponding standard error.
 }
 \description{
-\code{se = TRUE}, the jackknife se's from \code{logmeanexp} are
- squared, summed and the squared root is taken.
+This function computes the \code{\link[pomp]{logmeanexp}} for each column
+   or row of a numeric matrix and sums the result. Because the loglikelihood
+   of a \code{panelPomp} object is the sum of the loglikelihoods of its units,
+   this function can be used to summarize replicated estimates of the
+   \code{panelPomp} model likelihood. If \code{se = TRUE}, the jackknife SE estimates
+   from \code{\link[pomp]{logmeanexp}} are squared, summed and the squared root is taken.
 }
 \examples{
 ulls <- matrix(c(1,1,10,10),nr=2)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,17 @@
+REXE = R --vanilla
+
+SAVED = $(wildcard *.Rout.save *.Rout)
+
+default: $(SAVED) clean
+
+%.Rout.save: %.R
+	$(REXE) < $*.R > $*.Rout.save 2>&1
+
+%.Rout: %.R
+	$(REXE) < $*.R > $*.Rout 2>&1
+
+clean:
+	$(RM) *.c *.o *.so 
+
+fresh: clean
+	$(RM) *.png

--- a/tests/_options.R
+++ b/tests/_options.R
@@ -1,2 +1,1 @@
 suppressPackageStartupMessages(library(pomp))
-options(echo = TRUE)

--- a/tests/_options.R
+++ b/tests/_options.R
@@ -1,1 +1,2 @@
 suppressPackageStartupMessages(library(pomp))
+options(echo = TRUE)

--- a/tests/_options.Rout.save
+++ b/tests/_options.Rout.save
@@ -1,11 +1,13 @@
 
 R version 4.2.3 (2023-03-15) -- "Shortstop Beagle"
 Copyright (C) 2023 The R Foundation for Statistical Computing
-Platform: aarch64-apple-darwin20 (64-bit)
+Platform: x86_64-apple-darwin17.0 (64-bit)
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
 Type 'license()' or 'licence()' for distribution details.
+
+  Natural language support but running in an English locale
 
 R is a collaborative project with many contributors.
 Type 'contributors()' for more information and
@@ -17,6 +19,3 @@ Type 'q()' to quit R.
 
 > suppressPackageStartupMessages(library(pomp))
 > 
-> proc.time()
-   user  system elapsed 
-  0.316   0.026   0.338 

--- a/tests/mif2.R
+++ b/tests/mif2.R
@@ -24,8 +24,7 @@ test(wQuotes(ep,"pomp's ''mif2'' error message: in ''mif2'': the following ",
              "in ''params'': ''X.0''. (panelPomp:::mif2.internal)\n"),
      mif2(panelPomp(unitobjects(ppo)),Np=10,rw.sd=rw_sd(sigmaX=0.05,X.0=0.5),
          cooling.fraction.50=0.5,sh=pparams(ppo)$sh))
-test(wQuotes(ep,"pomp's ''mif2'' error message: in ''mif2'': 'arg' must be ",
-             "of length 1 (panelPomp:::mif2.internal)\n"),
+test(wQuotes(ep,"a parameter cannot be both shared and specific!", et),
      mif2(panelPomp(unitobjects(ppo),shared=coef(po)),Np=10,sp=pparams(ppo)$sp,
           rw.sd=rw_sd(sigmaX=0.05,X.0=0.5),cooling.fraction.50=0.5))
 ## assign parameters

--- a/tests/mif2.R
+++ b/tests/mif2.R
@@ -24,6 +24,8 @@ test(wQuotes(ep,"pomp's ''mif2'' error message: in ''mif2'': the following ",
              "in ''params'': ''X.0''. (panelPomp:::mif2.internal)\n"),
      mif2(panelPomp(unitobjects(ppo)),Np=10,rw.sd=rw_sd(sigmaX=0.05,X.0=0.5),
          cooling.fraction.50=0.5,sh=pparams(ppo)$sh))
+
+# Testing error message if a parameter is both shared and specific
 test(wQuotes(ep,"a parameter cannot be both shared and specific!", et),
      mif2(panelPomp(unitobjects(ppo),shared=coef(po)),Np=10,sp=pparams(ppo)$sp,
           rw.sd=rw_sd(sigmaX=0.05,X.0=0.5),cooling.fraction.50=0.5))
@@ -111,12 +113,19 @@ wQuotes(ep,"specify EITHER ''start'' only OR ''shared.start'' and/or",
 test(err,mif2(mf,Nmif=2,start=coef(mf),sh=2*ppo@shared,sp=2*ppo@specific))
 test(err,mif2(mf,Nmif=2,start=coef(mf),sp=2*ppo@specific))
 test(err,mif2(mf,Nmif=2,start=coef(mf),sh=2*ppo@shared))
-
 test(dim(traces(mf)),c(3L,7L))
 test(dim(traces(mf,c("loglik","sigmaY"))),c(3L,2L))
 test(dim(traces(mf,c("loglik","sigmaY","X.0"))),c(3L,4L))
 test(dim(traces(mf,c("loglik","unitLoglik"))),c(3L,3L))
 
+# Testing if parameter is both shared and specific (mif2d)
+sh_pars <- c("sigmaX" = 1, "sigmaY" = 1)
+sp_pars <- rbind(mf@specific, c(1, 1))
+rownames(sp_pars) <- c(rownames(mf@specific), "sigmaX")
+test(
+  wQuotes(ep,"a parameter cannot be both shared and specific! (''mif2,mif2d.ppomp-method'')\n"),
+  mif2(mf, Nmif = 2, shared.start = sh_pars, specific.start = sp_pars)
+)
 
 ## check whether all tests passed
 all(get(eval(formals(test))$all))

--- a/tests/mif2.Rout.save
+++ b/tests/mif2.Rout.save
@@ -1,11 +1,13 @@
 
 R version 4.2.3 (2023-03-15) -- "Shortstop Beagle"
 Copyright (C) 2023 The R Foundation for Statistical Computing
-Platform: aarch64-apple-darwin20 (64-bit)
+Platform: x86_64-apple-darwin17.0 (64-bit)
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
 Type 'license()' or 'licence()' for distribution details.
+
+  Natural language support but running in an English locale
 
 R is a collaborative project with many contributors.
 Type 'contributors()' for more information and
@@ -46,8 +48,9 @@ Type 'q()' to quit R.
 +      mif2(panelPomp(unitobjects(ppo)),Np=10,rw.sd=rw_sd(sigmaX=0.05,X.0=0.5),
 +          cooling.fraction.50=0.5,sh=pparams(ppo)$sh))
 [1] TRUE
-> test(wQuotes(ep,"pomp's ''mif2'' error message: in ''mif2'': 'arg' must be ",
-+              "of length 1 (panelPomp:::mif2.internal)\n"),
+> 
+> # Testing error message if a parameter is both shared and specific
+> test(wQuotes(ep,"a parameter cannot be both shared and specific!", et),
 +      mif2(panelPomp(unitobjects(ppo),shared=coef(po)),Np=10,sp=pparams(ppo)$sp,
 +           rw.sd=rw_sd(sigmaX=0.05,X.0=0.5),cooling.fraction.50=0.5))
 [1] TRUE
@@ -150,7 +153,6 @@ Type 'q()' to quit R.
 [1] TRUE
 > test(err,mif2(mf,Nmif=2,start=coef(mf),sh=2*ppo@shared))
 [1] TRUE
-> 
 > test(dim(traces(mf)),c(3L,7L))
 [1] TRUE
 > test(dim(traces(mf,c("loglik","sigmaY"))),c(3L,2L))
@@ -160,12 +162,18 @@ Type 'q()' to quit R.
 > test(dim(traces(mf,c("loglik","unitLoglik"))),c(3L,3L))
 [1] TRUE
 > 
+> # Testing if parameter is both shared and specific (mif2d)
+> sh_pars <- c("sigmaX" = 1, "sigmaY" = 1)
+> sp_pars <- rbind(mf@specific, c(1, 1))
+> rownames(sp_pars) <- c(rownames(mf@specific), "sigmaX")
+> test(
++   wQuotes(ep,"a parameter cannot be both shared and specific! (''mif2,mif2d.ppomp-method'')\n"),
++   mif2(mf, Nmif = 2, shared.start = sh_pars, specific.start = sp_pars)
++ )
+[1] TRUE
 > 
 > ## check whether all tests passed
 > all(get(eval(formals(test))$all))
 [1] TRUE
 > if (!all(get(eval(formals(test))$all))) stop("Not all tests passed!")
 > 
-> proc.time()
-   user  system elapsed 
-  0.701   0.129   1.033 

--- a/tests/panelPomp_methods.R
+++ b/tests/panelPomp_methods.R
@@ -62,6 +62,13 @@ test(list(shared=numeric(0),specific=ppo@specific),
                             value=TRUE)]))
 ## both sh & sp
 test(pParams(coef(ppo)),list(shared=ppo@shared,specific=ppo@specific))
+
+# Test error message if pParams used on data.frame
+test(
+  wQuotes("Error : in ''pParams'': ", "input must be a vector.\n"),
+  pParams(data.frame('par1' = 1, 'par2' = 2))
+)
+
 ## test unitobjects,panelPomp-method
 test(unitobjects(ppo),ppo@unit.objects)
 coef(ppo[["rw1"]])

--- a/tests/panelPomp_methods.Rout.save
+++ b/tests/panelPomp_methods.Rout.save
@@ -1,11 +1,13 @@
 
 R version 4.2.3 (2023-03-15) -- "Shortstop Beagle"
 Copyright (C) 2023 The R Foundation for Statistical Computing
-Platform: aarch64-apple-darwin20 (64-bit)
+Platform: x86_64-apple-darwin17.0 (64-bit)
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
 Type 'license()' or 'licence()' for distribution details.
+
+  Natural language support but running in an English locale
 
 R is a collaborative project with many contributors.
 Type 'contributors()' for more information and
@@ -95,6 +97,14 @@ Type 'q()' to quit R.
 > ## both sh & sp
 > test(pParams(coef(ppo)),list(shared=ppo@shared,specific=ppo@specific))
 [1] TRUE
+> 
+> # Test error message if pParams used on data.frame
+> test(
++   wQuotes("Error : in ''pParams'': ", "input must be a vector.\n"),
++   pParams(data.frame('par1' = 1, 'par2' = 2))
++ )
+[1] TRUE
+> 
 > ## test unitobjects,panelPomp-method
 > test(unitobjects(ppo),ppo@unit.objects)
 [1] TRUE
@@ -136,7 +146,7 @@ sigmaX sigmaY    X.0
 > 
 > ## show
 > show(ppo)
-<object of class 'panelPomp'>
+<object of class ‘panelPomp’>
 panel of 2 units 
 parameter(s):
 $shared
@@ -149,19 +159,16 @@ param rw1 rw2
   X.0   0 0.1
 
 summary of first panel unit ("rw1"):
-<object of class 'pomp'>
+<object of class ‘pomp’>
 > show(panelPomp(unitobjects(ppo)))
-<object of class 'panelPomp'>
+<object of class ‘panelPomp’>
 panel of 2 units 
 parameter(s) unspecified
 summary of first panel unit ("rw1"):
-<object of class 'pomp'>
+<object of class ‘pomp’>
 > 
 > ## check whether all tests passed
 > all(get(eval(formals(test))$all))
 [1] TRUE
 > if (!all(get(eval(formals(test))$all))) stop("Not all tests passed!")
 > 
-> proc.time()
-   user  system elapsed 
-  0.794   0.209   1.383 

--- a/tests/pfilter.R
+++ b/tests/pfilter.R
@@ -20,6 +20,31 @@ test(wQuotes(ep,"names of ''shared'' must match those of ",
   "''object@shared''.\n"),
   pfilter(panelPomp(unitobjects(ppo)),sh=pparams(ppo)$sh,Np=10))
 test(wQuotes(ep,"Missing ''Np'' argument.\n"),pfilter(ppo))
+
+# Testing error message if params argument is list without shared / specific elements
+test(
+  wQuotes(ep, "''params'' must be a list containing ''shared'' and ",
+          "''specific'' elements, or a named numeric vector.\n"),
+  pfilter(
+    ppo, Np = 10, params = list(shard = ppo@shared, spesific = ppo@specific)
+  )
+)
+test(
+  wQuotes(ep, "''params'' must be a list containing ''shared'' and ",
+  "''specific'' elements, or a named numeric vector.\n"),
+  pfilter(
+    ppo, Np = 10, params = list(shared = ppo@shared)
+  )
+)
+test(
+  wQuotes(ep, "''params'' must be a list containing ''shared'' and ",
+          "''specific'' elements, or a named numeric vector.\n"),
+  pfilter(
+    ppo, Np = 10, params = list(specific = ppo@specific)
+  )
+)
+
+
 ## assign parameters
 test(coef(pfilter(ppo,Np=10)),coef(ppo))
 test(coef(as(pfilter(ppo,sh=2*ppo@shared,sp=2*ppo@specific,Np=10),

--- a/tests/pfilter.Rout.save
+++ b/tests/pfilter.Rout.save
@@ -1,11 +1,13 @@
 
 R version 4.2.3 (2023-03-15) -- "Shortstop Beagle"
 Copyright (C) 2023 The R Foundation for Statistical Computing
-Platform: aarch64-apple-darwin20 (64-bit)
+Platform: x86_64-apple-darwin17.0 (64-bit)
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
 Type 'license()' or 'licence()' for distribution details.
+
+  Natural language support but running in an English locale
 
 R is a collaborative project with many contributors.
 Type 'contributors()' for more information and
@@ -41,6 +43,34 @@ Type 'q()' to quit R.
 [1] TRUE
 > test(wQuotes(ep,"Missing ''Np'' argument.\n"),pfilter(ppo))
 [1] TRUE
+> 
+> # Testing error message if params argument is list without shared / specific elements
+> test(
++   wQuotes(ep, "''params'' must be a list containing ''shared'' and ",
++           "''specific'' elements, or a named numeric vector.\n"),
++   pfilter(
++     ppo, Np = 10, params = list(shard = ppo@shared, spesific = ppo@specific)
++   )
++ )
+[1] TRUE
+> test(
++   wQuotes(ep, "''params'' must be a list containing ''shared'' and ",
++   "''specific'' elements, or a named numeric vector.\n"),
++   pfilter(
++     ppo, Np = 10, params = list(shared = ppo@shared)
++   )
++ )
+[1] TRUE
+> test(
++   wQuotes(ep, "''params'' must be a list containing ''shared'' and ",
++           "''specific'' elements, or a named numeric vector.\n"),
++   pfilter(
++     ppo, Np = 10, params = list(specific = ppo@specific)
++   )
++ )
+[1] TRUE
+> 
+> 
 > ## assign parameters
 > test(coef(pfilter(ppo,Np=10)),coef(ppo))
 [1] TRUE
@@ -132,6 +162,3 @@ Type 'q()' to quit R.
 [1] TRUE
 > if (!all(get(eval(formals(test))$all))) stop("Not all tests passed!")
 > 
-> proc.time()
-   user  system elapsed 
-  0.881   0.206   1.474 


### PR DESCRIPTION
Minor bug fixes and improvements to documentation. The primary goal of these changes is to improve user experience, primarily achieved by adding helpful error messages for previously unexpected inputs.

The following changes were made:

- Updated GitHub actions. The biggest difference is changing `r-lib/actions/setup-r@v2.3.1 -> r-lib/actions/setup-r@v2`; the version `2.3.1` is now outdated and does not work properly. I changed this to version `v2` because this is the "rolling" version, meaning that it always represents the latest version of this action, other than a potential major or breaking update. This change, along with the other changes to the GitHub Actions, is in line with changes to these files in the `pomp` and `spatPomp` packages. 
- Added a type check for the params argument of the `pfilter` function in order to throw more user friendly error.
- A more user friendly error is thrown when the user specifies a parameter as both shared and unit specific in the `mif2` function.
- Added a `match.arg` call in `mif2.internal` this will allow the default option for the `cooling.type` argument in `mif2` to no longer throw an error, and mimics the behavior of the `mif2` function in the `pomp` package.  This also results in removing an unintended and difficult to interpret error message. 
- The `pParams` function no longer changes the order of the unit specific parameter names; this was causing an error because the barycentric parameter transformation requires that the parameters are adjacent to one another in the parameter vector.
- Improved documentation for `panel_logmeanexp`, based on comments from students who have tried using this function and didn't think it provided enough detail.
- More robust input checking for the `pfilter` function with user friendly error messages.